### PR TITLE
fix(build) Disable modern flag due to issues with bundle.

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "serve": "vue-cli-service serve",
-    "build": "vue-cli-service build --modern",
+    "build": "vue-cli-service build",
     "lint": "vue-cli-service lint",
     "test:unit": "vue-cli-service test:unit"
   },


### PR DESCRIPTION
Once uploaded this returned an error relating to the crypto pollyfills added by AWS so I am just turning it off for now.