### PR TITLE
Modified to take advantage of aws amplify modularity,

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ To host a website on a custom URL using AWS mobile I have found some changes to 
 For a more detailed explanation on how things work, checkout:
 
 * [AWS Amplify Documentation](https://aws.github.io/aws-amplify/)
+* [AWS Amplify Modularization](https://github.com/aws-amplify/amplify-js/wiki/Amplify-modularization)
 * [docs for vue-cli](https://cli.vuejs.org/)
 * [docs for vue-router](http://router.vuejs.org/en/)
 * [docs for vuex](https://vuex.vuejs.org/)

--- a/package.json
+++ b/package.json
@@ -9,8 +9,8 @@
     "test:unit": "vue-cli-service test:unit"
   },
   "dependencies": {
-    "amazon-cognito-identity-js": "^2.0.9",
-    "aws-amplify": "^0.4.4",
+    "@aws-amplify/auth": "^1.2.3",
+    "@aws-amplify/core": "^1.0.12",
     "bootstrap-vue": "^2.0.0-rc.11",
     "vue": "^2.5.16",
     "vue-awesome": "^2.3.7",

--- a/src/main.js
+++ b/src/main.js
@@ -4,11 +4,10 @@ import Icon from 'vue-awesome/components/Icon'
 import App from '@/App.vue'
 import router from '@/router'
 import store from '@/store'
-import Amplify from 'aws-amplify'
-import aws_exports from '@/aws-exports'
+import Auth from "@aws-amplify/auth"
+import AuthConfig from '@/aws-exports'
 
-Amplify.Logger.LOG_LEVEL = 'DEBUG' // to show detailed logs from Amplify library
-Amplify.configure(aws_exports)
+Auth.configure(AuthConfig)
 
 Vue.use(BootstrapVue)
 Vue.component('icon', Icon)

--- a/src/pages/auth/SignUp.vue
+++ b/src/pages/auth/SignUp.vue
@@ -64,11 +64,11 @@
 <script>
 import Vue from "vue"
 import router from "@/router"
-
-import { Logger } from "aws-amplify"
 import { mapGetters } from "vuex"
-
 import Alert from "@/components/auth/Alert.vue"
+import Amplify from "@aws-amplify/core"
+
+const Logger = Amplify.Logger
 
 Vue.component("v-alert", Alert)
 

--- a/src/store/modules/auth.js
+++ b/src/store/modules/auth.js
@@ -1,5 +1,8 @@
-import { Auth, Logger } from 'aws-amplify'
+import Auth from "@aws-amplify/auth"
+import Amplify from "@aws-amplify/core"
 
+const Logger = Amplify.Logger
+Logger.LOG_LEVEL = "DEBUG" // to show detailed logs from Amplify library
 const logger = new Logger("store:auth")
 
 // initial state


### PR DESCRIPTION
in order to reduce bundle size. By only importing the modules actually used, the final bundle size changed as follows:

 - before: 1.3 MiB
 - after: 858 KiB

That's a 34% improvement, but more importantly it shows the improved way of using AWS Amplify going further.